### PR TITLE
Build a criteo-specific version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ import re
 import struct
 import subprocess
 import sys
+import time
 import warnings
 
 from setuptools import Extension, setup
@@ -27,7 +28,19 @@ def get_version():
 
 
 NAME = "Pillow-SIMD"
-PILLOW_VERSION = get_version()
+
+
+def _check_add_criteo_environment(package_version):
+    # Check both cases because soon criteois.lan will change to crto.in
+    if "JENKINS_URL" in os.environ and "crto.in" in os.environ["JENKINS_URL"]:
+        return f"42.0+criteo.{int(time.time())}_Upst_{package_version}"
+
+    return package_version
+
+
+UPSTREAM_VERSION = get_version()
+PILLOW_VERSION = _check_add_criteo_environment(UPSTREAM_VERSION)
+
 FREETYPE_ROOT = None
 HARFBUZZ_ROOT = None
 FRIBIDI_ROOT = None

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -113,7 +113,7 @@ try:
     # and should be considered private and subject to change.
     from . import _imaging as core
 
-    if __version__ != getattr(core, "PILLOW_VERSION", None):
+    if __version__ not in getattr(core, "PILLOW_VERSION", None):
         raise ImportError(
             "The _imaging extension was built for another version of Pillow or PIL:\n"
             f"Core version: {getattr(core, 'PILLOW_VERSION', None)}\n"


### PR DESCRIPTION
Changes proposed in this pull request:

 * Generates a criteo version number for the criteo build to always be chosen instead of official build
 * 
 * 
